### PR TITLE
Add conditional check for 'vc' value of 'None' (#102)

### DIFF
--- a/mdast_cli/distribution_systems/gpapi/googleplay.py
+++ b/mdast_cli/distribution_systems/gpapi/googleplay.py
@@ -155,8 +155,11 @@ class GooglePlayAPI(object):
 
         headers = self.getHeaders()
         params = {'ot': str(offerType),
-                  'doc': packageName,
-                  'vc': str(versionCode)}
+                  'doc': packageName}
+        
+        if versionCode != "None"
+            params['vc'] = str(versionCode)
+            
         response = requests.post(PURCHASE_URL, headers=headers,
                                  params=params,
                                  timeout=60)

--- a/mdast_cli/distribution_systems/gpapi/googleplay.py
+++ b/mdast_cli/distribution_systems/gpapi/googleplay.py
@@ -3,6 +3,7 @@ import ssl
 from base64 import b64decode, urlsafe_b64encode
 
 import requests
+import os
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -157,7 +158,8 @@ class GooglePlayAPI(object):
         params = {'ot': str(offerType),
                   'doc': packageName}
         
-        if str(versionCode) != "None":
+        vcNone = os.environ.get('MDASTCLI_SEND_NONE_VC', '')
+        if (str(versionCode) != "None") or (vcNone != "true"):
             params['vc'] = str(versionCode)
             
         response = requests.post(PURCHASE_URL, headers=headers,

--- a/mdast_cli/distribution_systems/gpapi/googleplay.py
+++ b/mdast_cli/distribution_systems/gpapi/googleplay.py
@@ -157,7 +157,7 @@ class GooglePlayAPI(object):
         params = {'ot': str(offerType),
                   'doc': packageName}
         
-        if versionCode != "None"
+        if str(versionCode) != "None":
             params['vc'] = str(versionCode)
             
         response = requests.post(PURCHASE_URL, headers=headers,


### PR DESCRIPTION
Hi @Dynamic-Mobile-Security 
There are cases where Google API returns DF-DFERH-01 when vc=None is occasionally sent. (#102)

To address this issue, it appears that we need to implement optional logic for handling `vc=None`. We can start by introducing an environment variable called `MDASTCLI_SEND_NONE_VC`. If this variable is not set or has an arbitrary value, we can continue sending vc=None as we did previously. However, if the environment variable is set to true, we can implement logic to exclude the vc parameter when vc is None.

```python
        vcNone = os.environ.get('MDASTCLI_SEND_NONE_VC', '')
        if (str(versionCode) != "None") or (vcNone != "true"):
            params['vc'] = str(versionCode)
```

While we're not certain if this approach is suitable, it should provide temporary relief. I've already sent the pull request; please let me know your thoughts ;D