### PR TITLE
Up cffi version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ altgraph==0.17
 beautifulsoup4==4.10.0
 cachetools==4.1.1
 certifi>=2023.7.22
-cffi==1.15.0
+cffi>=1.15.0
 chardet>=3.0.4
 charset-normalizer==2.0.12
 cryptography>=37.0.2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'beautifulsoup4==4.10.0',
         'cachetools==4.1.1',
         'certifi>=2023.7.22',
-        'cffi==1.15.0',
+        'cffi>=1.15.0',
         'chardet>=3.0.4',
         'charset-normalizer==2.0.12',
         'cryptography>=37.0.2',


### PR DESCRIPTION
Replaced cffi==1.15.0 with cffi>=1.15.0 in requirements.txt and setup.py to ensure compatibility with Python 3.12 and higher.