### PR TITLE
STG-4928: allow microservices scans without --company_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,14 +200,15 @@ Without `--download_only`, the script will:
 platform, with **no change to the command line**:
 
 - **Monolith** - the classic all-in-one installation (`Token` auth, tenant carried
-  in the `/organizations/{company_id}/...` URL path).
+  in the `/organizations/{company_id}/...` URL path). `--company_id` is required.
 - **Microservices / Kubernetes** - the platform behind the Clark facade (`Bearer`
   auth with an organization token issued in the platform UI; the tenant is resolved
-  server-side, so `--company_id` is accepted but ignored).
+  server-side, so `--company_id` may be omitted).
 
 By default the CLI **auto-detects** the installation by probing `GET /rest/architectures/`
 and inspecting the response shape (it does not merely trust an HTTP 200). The same
-`--url`, `--token`, `--company_id` and scan flags are used either way.
+`--url`, `--token` and scan flags are used either way; `--company_id` is required
+only after the target has been identified as a monolith installation.
 
 ### Selecting the mode explicitly
 

--- a/mdast_cli/mdast_scan.py
+++ b/mdast_cli/mdast_scan.py
@@ -28,8 +28,8 @@ from mdast_cli.helpers.const import (ANDROID_EXTENSIONS, DEFAULT_ANDROID_ARCHITE
 from mdast_cli.helpers.exit_codes import ExitCode
 from mdast_cli.helpers.helpers import check_app_md5, resolve_report_targets
 from mdast_cli_core.token import mDastToken as mDast
-from mdast_cli_core.factory import (MODE_MICROSERVICES, ModeDetectionError, resolve_installation_mode,
-                                    tls_verify_enabled)
+from mdast_cli_core.factory import (MODE_MICROSERVICES, MODE_MONOLITH, ModeDetectionError,
+                                    resolve_installation_mode, tls_verify_enabled)
 from mdast_cli.cr_report_generator import generate_cr
 from mdast_cli import __version__
 
@@ -52,9 +52,13 @@ Usage examples:
     --google_play_email user@example.com \\
     --google_play_aas_token YOUR_TOKEN
 
-  # Start application scanning:
+  # Start application scanning on a monolith installation:
   mdast_cli --distribution_system file --file_path app.apk \\
     --url https://mdast.example.com --company_id 1 --token YOUR_TOKEN
+
+  # Start application scanning on a microservices installation (no company ID):
+  mdast_cli --distribution_system file --file_path app.apk \\
+    --url https://mdast.example.com --token YOUR_TOKEN
 
 For detailed information about specific distribution system see README.md
         ''',
@@ -303,7 +307,7 @@ For detailed information about specific distribution system see README.md
                                 'Example: https://mdast.example.com')
     scan_group.add_argument('--company_id', type=int,
                            help='Company ID in MDast system. '
-                                'Required parameter when starting scan (without --download_only). '
+                                'Required only for monolith scans; omitted for microservices installations. '
                                 'Can be found in company settings in MDast web interface.')
     scan_group.add_argument('--token', type=str,
                            help='CI/CD token for authentication and starting scan. '
@@ -461,11 +465,12 @@ For detailed information about specific distribution system see README.md
     elif args.distribution_system == 'appgallery' and args.appgallery_app_id is None:
         parser.error('"--distribution_system appgallery" requires "--appgallery_app_id" to be set')
 
-    # F13: при запуске скана (без --download_only) обязательны --url/--company_id/--token.
-    # Прежнее required=(not '-d') вычислялось в False и не работало.
+    # URL and token are required before installation-mode detection. company_id is
+    # validated after detection because microservices resolve the organization from
+    # the Bearer token, while the monolith carries it in /organizations/{id}/ URLs.
     if not args.download_only:
         missing = [name for name, val in (
-            ('--url', args.url), ('--company_id', args.company_id), ('--token', args.token),
+            ('--url', args.url), ('--token', args.token),
         ) if val in (None, '')]
         if missing:
             parser.error(
@@ -909,6 +914,10 @@ def main():
     except ModeDetectionError as ex:
         logger.error(str(ex))
         sys.exit(ExitCode.AUTH_ERROR if ex.auth_error else ExitCode.NETWORK_ERROR)
+
+    if installation_mode == MODE_MONOLITH and company_id is None:
+        logger.error('--company_id is required for monolith mode')
+        sys.exit(ExitCode.INVALID_ARGS)
 
     if installation_mode == MODE_MICROSERVICES:
         tls_verify = tls_verify_enabled()

--- a/tests/test_mode_detection.py
+++ b/tests/test_mode_detection.py
@@ -20,7 +20,7 @@ MONO_ARCH = [{'id': 1, 'type': 1, 'name': 'Android 11'}]
 
 def test_env_override_microservices(monkeypatch):
     monkeypatch.setenv('MDAST_CLI_MODE', 'microservices')
-    assert resolve_installation_mode(REST_URL, TOKEN, COMPANY_ID) == MODE_MICROSERVICES
+    assert resolve_installation_mode(REST_URL, TOKEN, None) == MODE_MICROSERVICES
 
 
 def test_env_override_monolith(monkeypatch):
@@ -37,7 +37,7 @@ def test_env_invalid_value(monkeypatch):
 def test_autodetect_microservices_by_payload(mocked_responses, monkeypatch):
     monkeypatch.delenv('MDAST_CLI_MODE', raising=False)
     mocked_responses.add(responses.GET, ARCH_URL, json=MS_ARCH)  # Bearer probe
-    assert resolve_installation_mode(REST_URL, TOKEN, COMPANY_ID) == MODE_MICROSERVICES
+    assert resolve_installation_mode(REST_URL, TOKEN, None) == MODE_MICROSERVICES
     assert mocked_responses.calls[0].request.headers['Authorization'] == f'Bearer {TOKEN}'
 
 

--- a/tests/test_negative_e2e.py
+++ b/tests/test_negative_e2e.py
@@ -26,6 +26,11 @@ def base_argv(tmp_apk, *extra):
             '--url', BASE_URL, '--company_id', '1', '--token', TOKEN, *extra]
 
 
+def argv_without_company_id(tmp_apk, *extra):
+    return ['--distribution_system', 'file', '--file_path', tmp_apk,
+            '--url', BASE_URL, '--token', TOKEN, *extra]
+
+
 def _register_ms_preamble(rsps, apk_md5, engine_status='STARTED', engine_type='ANDROID',
                           apps=None):
     """Everything up to (not including) upload/create, microservices shaped."""
@@ -228,8 +233,34 @@ def test_missing_file_path_exit_2(monkeypatch, tmp_path):
 
 
 def test_scan_without_credentials_exit_2(monkeypatch, tmp_apk):
-    """No --url/--company_id/--token and not --download_only -> argparse error (2)."""
+    """No --url/--token and not --download_only -> argparse error (2)."""
     assert run_main(monkeypatch, ['--distribution_system', 'file', '--file_path', tmp_apk]) == 2
+
+
+def test_download_only_without_scan_credentials_still_succeeds(monkeypatch, tmp_apk):
+    assert run_main(monkeypatch, [
+        '--download_only', '--distribution_system', 'file', '--file_path', tmp_apk,
+    ]) == 0
+
+
+def test_forced_monolith_without_company_id_exit_2(mocked_responses, monkeypatch, tmp_apk,
+                                                   monolith_mode, caplog):
+    assert run_main(monkeypatch, argv_without_company_id(tmp_apk)) == 2
+    assert '--company_id is required for monolith mode' in caplog.text
+    assert not mocked_responses.calls
+
+
+def test_autodetected_monolith_without_company_id_exit_2(mocked_responses, monkeypatch,
+                                                         tmp_apk, caplog):
+    monkeypatch.delenv('MDAST_CLI_MODE', raising=False)
+    monolith_architectures = [{'id': 1, 'name': 'Android 11', 'type': 1}]
+    mocked_responses.add(responses.GET, ARCH, json=monolith_architectures)
+    mocked_responses.add(responses.GET, ARCH, json=monolith_architectures)
+
+    assert run_main(monkeypatch, argv_without_company_id(tmp_apk)) == 2
+    assert '--company_id is required for monolith mode' in caplog.text
+    assert len(mocked_responses.calls) == 2
+    assert all('/organizations/' not in call.request.url for call in mocked_responses.calls)
 
 
 def test_cr_report_without_credentials_exit_2(monkeypatch, tmp_apk):

--- a/tests/test_smoke_flows.py
+++ b/tests/test_smoke_flows.py
@@ -47,12 +47,14 @@ def register_ms_happy_path(rsps, apk_md5, with_testcase=True):
              headers={'Content-Disposition': 'attachment; filename="dast_77.json"'})
 
 
-def ms_argv(tmp_apk, with_testcase=True):
+def ms_argv(tmp_apk, with_testcase=True, include_company_id=True):
     argv = ['--distribution_system', 'file', '--file_path', tmp_apk,
-            '--url', BASE_URL, '--company_id', '1', '--token', TOKEN,
+            '--url', BASE_URL, '--token', TOKEN,
             '--profile_id', '2',
             '--pdf_report_file_name', 'scan_report_pdf',
             '--summary_report_json_file_name', 'scan_report_json']
+    if include_company_id:
+        argv += ['--company_id', '1']
     if with_testcase:
         argv += ['--testcase_id', '5']
     return argv
@@ -76,12 +78,23 @@ def test_ms_full_flow_success(mocked_responses, monkeypatch, tmp_path, tmp_apk, 
     assert body['fsm_locked'] is True
 
 
+def test_ms_full_flow_without_company_id_when_forced(mocked_responses, monkeypatch, tmp_path,
+                                                     tmp_apk, apk_md5, no_sleep, ms_mode):
+    """The Ficus command omits technical organization IDs in microservices mode."""
+    monkeypatch.chdir(tmp_path)
+    register_ms_happy_path(mocked_responses, apk_md5)
+    exit_code = run_main(monkeypatch, ms_argv(tmp_apk, include_company_id=False))
+    assert exit_code == 0
+    assert (tmp_path / 'scan_report_pdf.pdf').read_bytes().startswith(b'%PDF')
+    assert (tmp_path / 'scan_report_json.json').exists()
+
+
 def test_ms_full_flow_with_autodetect(mocked_responses, monkeypatch, tmp_path, tmp_apk,
                                       apk_md5, no_sleep):
     monkeypatch.delenv('MDAST_CLI_MODE', raising=False)
     monkeypatch.chdir(tmp_path)
     register_ms_happy_path(mocked_responses, apk_md5)
-    exit_code = run_main(monkeypatch, ms_argv(tmp_apk))
+    exit_code = run_main(monkeypatch, ms_argv(tmp_apk, include_company_id=False))
     assert exit_code == 0
 
 


### PR DESCRIPTION
## Что изменено

- --company_id больше не требуется для микросервисного режима
- для монолита параметр по-прежнему обязателен и проверяется после определения режима
- технический ID не нужен команде, которую формирует Ficus
- README и примеры запуска приведены в соответствие с поведением

## Проверка

- полный набор: 166 passed
- security-набор: 18 passed, 148 deselected
- compileall и git diff --check: успешно
- добавлены проверки принудительного и автоматически определённого микросервисного режима без company_id
- добавлены проверки отказа монолита без company_id до tenant-scoped API

Tracker: https://tracker.yandex.ru/STG-4928

Версию и тег в этом PR не меняем. После merge будет выпущен свежий тег, который отдельно обновим в Стинге и Markea.