### PR TITLE
STG-4588 Передавать os_version в pre-check и создание скана

### DIFF
--- a/mdast_cli/ms_flow.py
+++ b/mdast_cli/ms_flow.py
@@ -19,7 +19,8 @@ import time
 
 import requests
 
-from mdast_cli.helpers.const import (ACTIVE_STAGES, ANDROID_EXTENSIONS, END_SCAN_TIMEOUT, LONG_TRY, OS_ANDROID,
+from mdast_cli.helpers.const import (ACTIVE_STAGES, ANDROID_EXTENSIONS, DEFAULT_ANDROID_ARCHITECTURE,
+                                     DEFAULT_IOS_ARCHITECTURE, END_SCAN_TIMEOUT, LONG_TRY, OS_ANDROID,
                                      OS_IOS, PRE_START_STAGES, SLEEP_TIMEOUT, TERMINAL_SCAN_PAIRS, TRY,
                                      UPLOAD_TIMEOUT_ENV_VAR, UPLOAD_TIMEOUT_MAX, UPLOAD_TIMEOUT_MIN,
                                      ENGINE_ACTIVE_STATUS, ScanStage, ScanStageStatus)
@@ -73,6 +74,31 @@ def resolve_platform(app_file):
         return OS_ANDROID
     if extension.lower() == '.ipa':
         return OS_IOS
+
+
+def resolve_ms_os_version(architectures, platform):
+    """Choose a deterministic Scanyon OS version for a CLI scan."""
+    if not isinstance(architectures, list):
+        return None
+
+    candidates = [
+        architecture for architecture in architectures
+        if isinstance(architecture, dict)
+        and str(architecture.get('type', '')).upper() == platform
+        and str(architecture.get('os_version', '')).strip()
+    ]
+    if not candidates:
+        return None
+
+    preferred_name = {
+        OS_ANDROID: DEFAULT_ANDROID_ARCHITECTURE,
+        OS_IOS: DEFAULT_IOS_ARCHITECTURE,
+    }.get(platform)
+    selected = next(
+        (architecture for architecture in candidates if architecture.get('name') == preferred_name),
+        candidates[0],
+    )
+    return str(selected['os_version']).strip()
     return None
 
 
@@ -183,7 +209,7 @@ def _get_scan(mdast, scan_id):
     return _json_or_exit(resp, f'Getting scan info for scan {scan_id}')
 
 
-def run_precheck_gate(mdast, md5, profile_id, testcase_id, scan_type):
+def run_precheck_gate(mdast, md5, profile_id, testcase_id, scan_type, os_version=None):
     """Gate model (DEC-671-05): any warning blocks the scan with a non-zero exit.
 
     A transient gateway failure (429/502/503/504) or a raw network error is NOT a
@@ -194,7 +220,7 @@ def run_precheck_gate(mdast, md5, profile_id, testcase_id, scan_type):
     resp = None
     for attempt in range(UPLOAD_TRANSIENT_RETRIES):
         try:
-            resp = mdast.precheck_scan(md5, profile_id, testcase_id, scan_type)
+            resp = mdast.precheck_scan(md5, profile_id, testcase_id, scan_type, os_version=os_version)
         except requests.RequestException as ex:
             logger.warning(f'Scan pre-check request failed ({type(ex).__name__}), '
                            f'retry {attempt + 1}/{UPLOAD_TRANSIENT_RETRIES}')
@@ -296,6 +322,12 @@ def _run_microservices_flow(arguments, url, token, app_file, user_agent, verify)
         logger.error(f'Cannot resolve platform (Android/iOS) from file extension: {app_file}')
         sys.exit(ExitCode.INVALID_ARGS)
 
+    os_version = resolve_ms_os_version(architectures, platform)
+    if os_version is None:
+        logger.error(f'Cannot create scan - no supported OS version for platform {platform}')
+        sys.exit(ExitCode.SCAN_FAILED)
+    logger.info(f'Selected OS version for {platform}: {sanitize(os_version)}')
+
     if testcase_id is not None:
         testcase_resp = mdast.get_testcase(testcase_id)
         if testcase_resp.status_code == 200:
@@ -352,14 +384,16 @@ def _run_microservices_flow(arguments, url, token, app_file, user_agent, verify)
         sys.exit(ExitCode.SCAN_FAILED)
 
     precheck_type = 'AUTO' if testcase_id is not None else 'MANUAL'
-    run_precheck_gate(mdast, app_md5, profile_id, testcase_id, precheck_type)
+    run_precheck_gate(mdast, app_md5, profile_id, testcase_id, precheck_type, os_version=os_version)
 
     logger.info(f'Creating scan for application {sanitize(app_id)}')
     if testcase_id is not None:
-        create_resp = mdast.create_auto_scan(project_id, profile_id, app_md5, None, testcase_id)
+        create_resp = mdast.create_auto_scan(
+            project_id, profile_id, app_md5, None, testcase_id, os_version=os_version,
+        )
         scan_type = 'auto_stingray'
     else:
-        create_resp = mdast.create_manual_scan(project_id, profile_id, app_md5)
+        create_resp = mdast.create_manual_scan(project_id, profile_id, app_md5, os_version=os_version)
         scan_type = 'manual'
     if create_resp.status_code not in (200, 201):
         _exit_on_http_error(create_resp, 'Creating scan')

--- a/mdast_cli_core/microservices.py
+++ b/mdast_cli_core/microservices.py
@@ -155,7 +155,7 @@ class mDastMicroservices(mDastBase):
 
     # --- scan flow (STG-4475) ---
 
-    def precheck_scan(self, md5, profile_id, testcase_id, scan_type):
+    def precheck_scan(self, md5, profile_id, testcase_id, scan_type, os_version=None):
         """Gate pre-check before scan creation (DEC-671-05).
 
         Field is `application_md5` in the scanyon contract (not `md5`).
@@ -168,13 +168,15 @@ class mDastMicroservices(mDastBase):
             'type': scan_type,
             'testcase_id': testcase_id,
         }
+        if os_version is not None:
+            data['os_version'] = os_version
         return requests.post(f'{self.url}/scans/start/precheck/',
                              headers=self.headers,
                              data=json.dumps(data),
                              verify=self.verify,
                              timeout=self.timeout)
 
-    def _create_scan(self, project_id, profile_id, app_md5, test_case_id, scan_type):
+    def _create_scan(self, project_id, profile_id, app_md5, test_case_id, scan_type, os_version=None):
         # scanyon: AUTO requires testcase_id; a scan without a test case is MANUAL
         # (install/launch/wait/stop semantics, wait=True on the server side).
         # testcase_id key is mandatory in ScanIn even when null.
@@ -188,18 +190,22 @@ class mDastMicroservices(mDastBase):
             data['project_id'] = project_id
         if profile_id:
             data['profile_id'] = profile_id
+        if os_version is not None:
+            data['os_version'] = os_version
         return requests.post(f'{self.url}/scans/start/',
                              headers=self.headers,
                              data=json.dumps(data),
                              verify=self.verify,
                              timeout=self.timeout)
 
-    def create_manual_scan(self, project_id, profile_id, app_md5, arch_id=None):
+    def create_manual_scan(self, project_id, profile_id, app_md5, arch_id=None, os_version=None):
         # arch_id accepted and ignored (microservices resolve platform from app metadata)
-        return self._create_scan(project_id, profile_id, app_md5, None, 'MANUAL')
+        return self._create_scan(project_id, profile_id, app_md5, None, 'MANUAL', os_version=os_version)
 
-    def create_auto_scan(self, project_id, profile_id, app_md5, arch_id, test_case_id):
-        return self._create_scan(project_id, profile_id, app_md5, test_case_id, 'AUTO')
+    def create_auto_scan(self, project_id, profile_id, app_md5, arch_id, test_case_id, os_version=None):
+        return self._create_scan(
+            project_id, profile_id, app_md5, test_case_id, 'AUTO', os_version=os_version,
+        )
 
     def create_appium_scan(self, project_id, profile_id, app_id, arch_id, appium_script_path):
         raise NotImplementedError(

--- a/tests/test_client_microservices.py
+++ b/tests/test_client_microservices.py
@@ -54,9 +54,9 @@ def test_testcase_url(client, mocked_responses):
 def test_create_scan_body_auto(client, mocked_responses):
     mocked_responses.add(responses.POST, f'{REST_URL}/scans/start/', json={'id': 1}, status=200)
     client.create_auto_scan(project_id=3, profile_id=4, app_md5='b' * 32,
-                            arch_id=999, test_case_id=5)
+                            arch_id=999, test_case_id=5, os_version='11')
     body = json.loads(last_request(mocked_responses).body)
-    assert body == {'md5': 'b' * 32, 'type': 'AUTO', 'testcase_id': 5,
+    assert body == {'md5': 'b' * 32, 'type': 'AUTO', 'testcase_id': 5, 'os_version': '11',
                     'fsm_locked': True, 'project_id': 3, 'profile_id': 4}
 
 
@@ -74,10 +74,12 @@ def test_create_scan_body_manual_is_manual_type(client, mocked_responses):
 def test_precheck_body_uses_application_md5_field(client, mocked_responses):
     mocked_responses.add(responses.POST, f'{REST_URL}/scans/start/precheck/',
                          json={'warnings': []})
-    client.precheck_scan('c' * 32, profile_id=7, testcase_id=None, scan_type='MANUAL')
+    client.precheck_scan(
+        'c' * 32, profile_id=7, testcase_id=None, scan_type='MANUAL', os_version='11',
+    )
     body = json.loads(last_request(mocked_responses).body)
     assert body == {'application_md5': 'c' * 32, 'profile_id': 7,
-                    'type': 'MANUAL', 'testcase_id': None}
+                    'type': 'MANUAL', 'testcase_id': None, 'os_version': '11'}
 
 
 def test_scan_lifecycle_urls(client, mocked_responses):

--- a/tests/test_ms_architecture.py
+++ b/tests/test_ms_architecture.py
@@ -1,0 +1,31 @@
+"""Unit tests for microservices OS-version selection (STG-4588)."""
+
+import pytest
+
+from mdast_cli.helpers.const import OS_ANDROID, OS_IOS
+from mdast_cli.ms_flow import resolve_ms_os_version
+
+pytestmark = pytest.mark.unit
+
+
+def test_prefers_default_architecture_name():
+    architectures = [
+        {'type': 'ANDROID', 'os_version': '14', 'name': 'Android 14'},
+        {'type': 'ANDROID', 'os_version': '11', 'name': 'Android 11'},
+    ]
+
+    assert resolve_ms_os_version(architectures, OS_ANDROID) == '11'
+
+
+def test_falls_back_to_first_platform_version():
+    architectures = [
+        {'type': 'ANDROID', 'os_version': '14', 'name': 'Android 14'},
+        {'type': 'IOS', 'os_version': '16', 'name': 'iOS 16'},
+    ]
+
+    assert resolve_ms_os_version(architectures, OS_IOS) == '16'
+
+
+@pytest.mark.parametrize('architectures', [None, {}, [], [{'type': 'ANDROID', 'os_version': ''}]])
+def test_missing_platform_version_returns_none(architectures):
+    assert resolve_ms_os_version(architectures, OS_ANDROID) is None

--- a/tests/test_smoke_flows.py
+++ b/tests/test_smoke_flows.py
@@ -75,7 +75,11 @@ def test_ms_full_flow_success(mocked_responses, monkeypatch, tmp_path, tmp_apk, 
     body = json.loads(create_calls[0].request.body)
     assert body['md5'] == apk_md5
     assert body['type'] == 'AUTO'
+    assert body['os_version'] == '11'
     assert body['fsm_locked'] is True
+    precheck_calls = [c for c in mocked_responses.calls
+                      if c.request.url == f'{REST_URL}/scans/start/precheck/']
+    assert json.loads(precheck_calls[0].request.body)['os_version'] == '11'
 
 
 def test_ms_full_flow_without_company_id_when_forced(mocked_responses, monkeypatch, tmp_path,
@@ -115,7 +119,9 @@ def test_ms_manual_flow_stops_scan(mocked_responses, monkeypatch, tmp_path, tmp_
 def test_ms_precheck_gate_blocks(mocked_responses, monkeypatch, tmp_path, tmp_apk, apk_md5,
                                  no_sleep, ms_mode, capsys):
     monkeypatch.chdir(tmp_path)
-    mocked_responses.add(responses.GET, f'{REST_URL}/architectures/', json=[])
+    mocked_responses.add(responses.GET, f'{REST_URL}/architectures/', json=[
+        {'id': 1, 'type': 'ANDROID', 'os_version': '11', 'name': 'Android 11'},
+    ])
     mocked_responses.add(responses.GET, f'{REST_URL}/testcases/5/', json={'os': 'ANDROID'})
     mocked_responses.add(responses.GET, f'{REST_URL}/engines/',
                          json=[{'type': 'ANDROID', 'status': 'STARTED'}])
@@ -134,7 +140,9 @@ def test_ms_precheck_gate_blocks(mocked_responses, monkeypatch, tmp_path, tmp_ap
 def test_ms_scan_fail_state(mocked_responses, monkeypatch, tmp_path, tmp_apk, apk_md5,
                             no_sleep, ms_mode):
     monkeypatch.chdir(tmp_path)
-    mocked_responses.add(responses.GET, f'{REST_URL}/architectures/', json=[])
+    mocked_responses.add(responses.GET, f'{REST_URL}/architectures/', json=[
+        {'id': 1, 'type': 'ANDROID', 'os_version': '11', 'name': 'Android 11'},
+    ])
     mocked_responses.add(responses.GET, f'{REST_URL}/testcases/5/', json={'os': 'ANDROID'})
     mocked_responses.add(responses.GET, f'{REST_URL}/engines/',
                          json=[{'type': 'ANDROID', 'status': 'STARTED'}])
@@ -159,7 +167,9 @@ def test_ms_start_409_facade_retry_is_tolerated(mocked_responses, monkeypatch, t
     (successful) call returns 409, but the scan did start. CLI must confirm by state
     and continue, not fail."""
     monkeypatch.chdir(tmp_path)
-    mocked_responses.add(responses.GET, f'{REST_URL}/architectures/', json=[])
+    mocked_responses.add(responses.GET, f'{REST_URL}/architectures/', json=[
+        {'id': 1, 'type': 'ANDROID', 'os_version': '11', 'name': 'Android 11'},
+    ])
     mocked_responses.add(responses.GET, f'{REST_URL}/testcases/5/', json={'os': 'ANDROID'})
     mocked_responses.add(responses.GET, f'{REST_URL}/engines/',
                          json=[{'type': 'ANDROID', 'status': 'STARTED'}])
@@ -183,7 +193,9 @@ def test_ms_start_409_real_conflict_fails(mocked_responses, monkeypatch, tmp_pat
                                           tmp_apk, apk_md5, no_sleep, ms_mode):
     """A genuine 409 (scan still in CREATED) must NOT be masked - CLI fails."""
     monkeypatch.chdir(tmp_path)
-    mocked_responses.add(responses.GET, f'{REST_URL}/architectures/', json=[])
+    mocked_responses.add(responses.GET, f'{REST_URL}/architectures/', json=[
+        {'id': 1, 'type': 'ANDROID', 'os_version': '11', 'name': 'Android 11'},
+    ])
     mocked_responses.add(responses.GET, f'{REST_URL}/testcases/5/', json={'os': 'ANDROID'})
     mocked_responses.add(responses.GET, f'{REST_URL}/engines/',
                          json=[{'type': 'ANDROID', 'status': 'STARTED'}])
@@ -199,6 +211,19 @@ def test_ms_start_409_real_conflict_fails(mocked_responses, monkeypatch, tmp_pat
                          json=scan_json(stage='CREATED', status='INITIAL'))
     exit_code = run_main(monkeypatch, ms_argv(tmp_apk) + ['--nowait'])
     assert exit_code == 5
+
+
+def test_ms_missing_platform_architecture_stops_before_upload(mocked_responses, monkeypatch,
+                                                              tmp_apk, ms_mode):
+    mocked_responses.add(responses.GET, f'{REST_URL}/architectures/', json=[
+        {'id': 3, 'type': 'IOS', 'os_version': '16', 'name': 'iOS 16'},
+    ])
+
+    exit_code = run_main(monkeypatch, ms_argv(tmp_apk))
+
+    assert exit_code == 5
+    urls = [call.request.url for call in mocked_responses.calls]
+    assert urls == [f'{REST_URL}/architectures/']
 
 
 def test_ms_appium_rejected(monkeypatch, tmp_apk, ms_mode):


### PR DESCRIPTION
## Контекст

Актуальная проверка контрактов показала, что `os_version` не должна приходить из Apricot: это параметр конкретного скана, уже поддержанный Scanyon в `POST /scans/start/precheck/` и `POST /scans/start/`. mdast-cli каталог архитектур получал, но версию ОС терял.

## Что изменено

- микросервисный flow выбирает архитектуру нужной платформы из `GET /architectures/`;
- сначала предпочитается штатное имя по умолчанию (`Android 11` / `iOS 14`), затем первая валидная запись платформы;
- одна и та же `os_version` передаётся в pre-check и создание скана;
- при отсутствии версии нужной платформы flow останавливается до загрузки и создания скана;
- новые параметры Python-клиента необязательны, сторонние вызовы остаются совместимыми;
- монолитный flow не менялся.

## Проверка

- полный набор: `173 passed`;
- security gate: `18 passed`;
- `compileall` и `git diff --check` прошли.

Tracker: https://tracker.yandex.ru/STG-4588