### PR TITLE
chore(ci): обновлены версии GitHub Actions

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -10,8 +10,8 @@ jobs:
     name: Tests gate before publish
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - run: pip install -r requirements.txt -r requirements-dev.txt
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: docker login
         env:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,8 +10,8 @@ jobs:
     name: Tests gate before publish
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v7
       with:
         python-version: '3.12'
     - run: pip install -r requirements.txt -r requirements-dev.txt
@@ -22,12 +22,12 @@ jobs:
     needs: tests
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v7
       with:
-        python-version: 3.12
+        python-version: '3.12'
 
 #    - name: Linter flake8
 #      uses: py-actions/flake8@v2.2.1
@@ -58,15 +58,15 @@ jobs:
         .
 
     - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_CLI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
 
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push'
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_CLI_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,10 @@ jobs:
     name: pytest (unit, contract, smoke, security)
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Runner-ы GitHub принудительно переводят Node 20 на Node 24, а ветка master у pypa/gh-action-pypi-publish закрыта (sunset) и не получает обновлений, включая исправления безопасности. Сейчас это предупреждения, но публикация пакета висит на неподдерживаемой ссылке.

- actions/checkout: v4, v3 и master -> v7
- actions/setup-python: v5 и v1 -> v7
- pypa/gh-action-pypi-publish: master -> release/v1
- repository_url -> repository-url (в release/v1 старое имя объявлено устаревшим)
- python-version взят в кавычки: без них YAML читает значение как число, и версия вида 3.10 превратилась бы в 3.1

Отдельно стоит отметить два места, которые остаются небезопасными по умолчанию и требуют отдельного решения:
- publish выполняется по паролю (API-токен в secrets); PyPI рекомендует секретless-публикацию через Trusted Publishing;
- ссылки на экшены не закреплены за конкретными SHA, поэтому владелец тега может подменить исполняемый код.